### PR TITLE
:bug: (myPage): FIX: 마이 페이지 이미지 조회 불가(엑박)

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,10 @@
 import * as S from "../src/commons/styles/home";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import { deviceState, userPositionState } from "../src/commons/store";
+import useMoveTo from "../src/commons/libraries/useMoveTo";
 
 export default function Home() {
-  const router = useRouter();
-  // const { data } = useQuery<Pick<IQuery, "fetchUser">>(FETCH_USER);
   const [, setIsMobile] = useRecoilState(deviceState);
   const [, setUserPosition] = useRecoilState(userPositionState);
   useEffect(() => {
@@ -101,9 +99,7 @@ export default function Home() {
           )}
         </S.ContentBox>
         <S.LastContent>
-          <S.GoToMainButton
-            onClick={async () => await router.push("/main/list")}
-          >
+          <S.GoToMainButton onClick={async () => await useMoveTo("/main/list")}>
             버스킹 즐기러 가기{" "}
           </S.GoToMainButton>
         </S.LastContent>

--- a/src/commons/libraries/moveToHome.ts
+++ b/src/commons/libraries/moveToHome.ts
@@ -1,8 +1,0 @@
-import { useRouter } from "next/router";
-
-const MoveToHome = () => {
-  const router = useRouter();
-  void router.push("/map");
-};
-
-export default MoveToHome;

--- a/src/commons/libraries/useMoveTo.ts
+++ b/src/commons/libraries/useMoveTo.ts
@@ -1,0 +1,8 @@
+import { useRouter } from "next/router";
+
+const useMoveTo = async (path: string) => {
+  const router = useRouter();
+  return await router.push(path);
+};
+
+export default useMoveTo;

--- a/src/components/common/kakaoMap/index.tsx
+++ b/src/components/common/kakaoMap/index.tsx
@@ -173,7 +173,7 @@ const KakaoMap = ({
                             </div>
                             <div className="desc">
                               <div className="ellipsis category">
-                                # {board.category.name}
+                                # {board.category?.name}
                               </div>
                               <div className="jibun ellipsis">
                                 시작: {startAt}

--- a/src/components/common/layout/footer/index.tsx
+++ b/src/components/common/layout/footer/index.tsx
@@ -1,3 +1,0 @@
-const Footer = () => {};
-
-export default Footer;

--- a/src/components/common/layout/index.tsx
+++ b/src/components/common/layout/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../commons/styles/globalStyles";
 import { IMutation, IQuery } from "../../../commons/types/generated/types";
 import { FETCH_USER } from "../../units/myPage/detail/MyPageDetail.queries";
-
+import useMoveTo from "../../../commons/libraries/useMoveTo";
 import Header from "./header";
 
 const LOGOUT = gql`
@@ -31,7 +31,7 @@ const Layout = ({ children }: ILayoutProps) => {
   const [logout] = useMutation<Pick<IMutation, "logout">>(LOGOUT);
 
   const onClickMove = (path: string) => async () => {
-    await router.push(path);
+    await useMoveTo(path);
     setIsOpen(false);
   };
 

--- a/src/components/units/artistDetail/ArtistDetail.presenter.tsx
+++ b/src/components/units/artistDetail/ArtistDetail.presenter.tsx
@@ -146,7 +146,7 @@ const ArtistDetailUI = (props: IArtistDetailProps) => {
                     fontSize: "1.2rem",
                   }}
                 >
-                  # {board.category.name}
+                  # {board.category?.name}
                 </span>
               </S.RecentInfo>
             </S.RecentArt>

--- a/src/components/units/artregister/artRegister.presenter.tsx
+++ b/src/components/units/artregister/artRegister.presenter.tsx
@@ -57,10 +57,11 @@ const ArtRegisterPageWriteUI = ({
           <S.GenreWrapper>
             <S.TextStyle>공연장르</S.TextStyle>
             <Select
-              placeholder="Please select"
+              placeholder="장르를 선택해주세요."
               onChange={handleChange}
               style={{ width: "100%" }}
               options={options}
+              defaultValue={isEdit ? data?.fetchBoard.category?.name : null}
             />
             <S.ErrorMsg>{formState.errors.genre?.message}</S.ErrorMsg>
           </S.GenreWrapper>
@@ -72,7 +73,7 @@ const ArtRegisterPageWriteUI = ({
                   {new Array(3).fill(3).map((_, index) => {
                     return (
                       <>
-                        {data?.fetchBoard.boardImageURL[index] ? (
+                        {data?.fetchBoard.boardImageURL?.[index] ? (
                           <>
                             <S.ImgBtn
                               style={{

--- a/src/components/units/detail/ArtDetail.presenter.tsx
+++ b/src/components/units/detail/ArtDetail.presenter.tsx
@@ -29,7 +29,7 @@ const ArtDetailUI = (props: IArtDetailProps) => {
         <S.ContentBox>
           <S.ArtistInfoBox>
             <ImageBox
-              src={`https://storage.googleapis.com/busker-storage/${String(
+              src={`https://storage.googleapis.com/busker_dev-storage/${String(
                 props.data?.fetchBoard.artist.artistImageURL
               )}`}
               width="75px"
@@ -43,7 +43,7 @@ const ArtDetailUI = (props: IArtDetailProps) => {
               <div style={{ fontSize: "1.5rem", color: "#6600FF" }}>버스커</div>
               {props.data?.fetchBoard.artist.active_name}
             </S.ArtistName>
-            <S.Genre># {props.data?.fetchBoard.category.name}</S.Genre>
+            <S.Genre># {props.data?.fetchBoard.category?.name}</S.Genre>
             {props.isArtist && (
               <S.ControllBox>
                 <EditOutlined onClick={props.onClickMoveToEdit} />

--- a/src/components/units/detail/ArtImageCarousel.tsx
+++ b/src/components/units/detail/ArtImageCarousel.tsx
@@ -25,7 +25,7 @@ const ImageCarousel = (props: ICarouselProps) => {
         {props.data?.map((images: IBoardImages, i: number) => (
           <ImageBox key={i}>
             <StyledImage
-              src={`https://storage.googleapis.com/busker-storage/${String(
+              src={`https://storage.googleapis.com/busker_dev-storage/${String(
                 images.url
               )}`}
             />

--- a/src/components/units/main/list/List.presenter.tsx
+++ b/src/components/units/main/list/List.presenter.tsx
@@ -45,7 +45,7 @@ const MainListUI = (props: IMainListProps) => {
                 board={board}
                 onClickListItem={props.onClickListItem}
               />
-            ))}
+            )) ?? <></>}
           </InfiniteScroll>
         </AnimatePresence>
       </S.ListBox>

--- a/src/components/units/main/list/ListItem.tsx
+++ b/src/components/units/main/list/ListItem.tsx
@@ -21,7 +21,7 @@ const ListItem = ({ board, onClickListItem }: IListItemProps) => {
       <Wrapper>
         <ImageBox>
           <Image
-            src={`https://storage.googleapis.com/busker-storage/${String(
+            src={`https://storage.googleapis.com/busker_dev-storage/${String(
               board?.boardImageURL[0]?.url
             )}`}
           />

--- a/src/components/units/myPage/detail/MyPageDetail.container.tsx
+++ b/src/components/units/myPage/detail/MyPageDetail.container.tsx
@@ -67,7 +67,7 @@ const MyPageDetail = () => {
         variables: { updateUserInput: { nickname, userImageURL: String(url) } },
         update(cache) {
           cache.modify({
-            fields: () => {},
+            fields: { fetchUser: () => {} },
           });
         },
       });

--- a/src/components/units/myPage/detail/MyPageDetail.presenter.tsx
+++ b/src/components/units/myPage/detail/MyPageDetail.presenter.tsx
@@ -16,12 +16,9 @@ const MyPageDetailUI = (props: IMyPageProps) => {
             <ImageBox
               width="72px"
               height="72px"
-              src={
-                props.userImageURL ??
-                `https://storage.googleapis.com/busker-storage/${String(
-                  props.data?.fetchUser.userImageURL
-                )}`
-              }
+              src={`https://storage.googleapis.com/busker_dev-storage/${String(
+                props.data?.fetchUser.userImageURL
+              )}`}
             />
             <div
               style={{
@@ -101,7 +98,7 @@ const MyPageDetailUI = (props: IMyPageProps) => {
                   height="72px"
                   src={
                     props.userImageURL ??
-                    `https://storage.googleapis.com/busker-storage/${String(
+                    `https://storage.googleapis.com/busker_dev-storage/${String(
                       props.data?.fetchUser.userImageURL
                     )}`
                   }


### PR DESCRIPTION
### 이슈
마이 페이지 유저 이미지 업데이트 시, 업데이트 된 최신 변경 사항이 적용은 되지만, 정상적인 이미지 대신 storage.googleapis.com에서 오는 404에러와 함께 엑스박스가 뜨는 현상

### 원인
이미지를 구글 스토리지에 업로드 후에 결과물로 받아온 url로 유저정보를 업데이트 했을 때, 구글 스토리지에 이미지 업로드가 완료되지 않아서 찾을 수 없는 url을 찾으려고 했기 때문. (404 에러가 난 것도 그 때문인 듯 함.)

### 해결
클라이언트 단에선 이미지 업로드 API와 유저 업데이트 API가 동기적으로 실행되고 있으므로, 서버 단에서의 동기적 실행이 필요해보인다고 판단.

서버 단에서 해결되기 전까지 원활한 작동을 위해 기존의
- 변경될 이미지 preview
- 변경된 이미지 프로필
두 가지를 하나로 합칠 에정
1. 기존의 이미지 프로필을 보여줌.
2. 유저가 변경할 이미지를 `<input type="file" />`에 업로드 하면, `state`를 사용해서 preview 제공.
3. 변경 요청을 날려도 여전히 `state`로 보여줌. (마치, 이미지가 변경이 적용된 것처럼)
    - 만약, 업로드 후에 변경 요청을 날리지 않으면 다시 들어올 때 기존의 이미지 프로필이 들어감.

closed #2 